### PR TITLE
Add option for IPv6 agent to request node

### DIFF
--- a/coap/coap-request.html
+++ b/coap/coap-request.html
@@ -11,6 +11,7 @@
                     );
                 },
             },
+            useIPv6Agent: { value: false, required: true },
             observe: { value: false, required: true },
             url: { value: "" },
             "content-format": { value: "text/plain" },
@@ -50,6 +51,10 @@
             <option value="POST">POST</option>
             <option value="DELETE">DELETE</option>
         </select>
+    </div>
+    <div class="form-row">
+        <input type="checkbox" id="node-input-useIPv6Agent" style="display: inline-block; width: auto; vertical-align: top;">
+        <label for="node-input-useIPv6Agent" style="width: auto" data-i18n="coapRequest.inputIPv6.label"></label>
     </div>
     <div class="form-row">
         <input type="checkbox" id="node-input-observe" style="display: inline-block; width: auto; vertical-align: top;">

--- a/coap/coap-request.js
+++ b/coap/coap-request.js
@@ -14,6 +14,7 @@ module.exports = function (RED) {
 
         // copy "coap request" configuration locally
         node.options = {};
+        node.options.useIPv6Agent = n.useIPv6Agent;
         node.options.method = n.method;
         node.options.observe = n.observe;
         node.options.name = n.name;
@@ -45,6 +46,10 @@ module.exports = function (RED) {
             ).toUpperCase();
             reqOpts.headers = {};
             reqOpts.headers["Content-Format"] = node.options.contentFormat;
+
+            if (node.options.useIPv6Agent) {
+                reqOpts.agent = coap.globalAgentIPv6;
+            }
 
             function _onResponse(res) {
                 function _send(payload) {

--- a/coap/locales/de/coap-request.json
+++ b/coap/locales/de/coap-request.json
@@ -9,6 +9,9 @@
             "label": "URL",
             "placeholder": "coap://localhost/test"
         },
+        "inputIPv6": {
+            "label": "IPv6-Agent verwenden"
+        },
         "inputMethod": {
             "label": "Methode"
         },

--- a/coap/locales/en-US/coap-request.json
+++ b/coap/locales/en-US/coap-request.json
@@ -9,6 +9,9 @@
             "label": "URL",
             "placeholder": "coap://localhost/test"
         },
+        "inputIPv6": {
+            "label": "Use IPv6 agent"
+        },
         "inputMethod": {
             "label": "Method"
         },


### PR DESCRIPTION
This PR is a potential fix for #15, adding an option to the request node for using a `globalAgentIPv6` in the underlying `node-coap` instead of its IPv4 counterpart.

Once it is merged, the PR may fix #15. More testing and investigation is required, however.