### PR TITLE
Add a CoAP response node

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project adds CoAP support to [Node-RED](http://nodered.org/). It is based o
 
 Functionality
 -------------
- We introduce "coap request" and "coap in" nodes which can be used in a similar fashion to "http request"and "http in" nodes from Node-RED's core.
+ We introduce "coap request", "coap in", and "coap response" nodes which can be used in a similar fashion to "http request", "http in", and "http reponse" nodes from Node-RED's core.
 
 Install
 -------

--- a/coap/coap-in.html
+++ b/coap/coap-in.html
@@ -2,9 +2,9 @@
 <script type="text/html" data-template-name="coap-server">
     <div class="form-row">
         <label for="node-config-input-name">
-            <i class="fa fa-bookmark"></i> <span data-i18n="coapServer.configInputName.label"></span>
+            <i class="fa fa-bookmark"></i> <span data-i18n="common.inputName.label"></span>
         </label>
-        <input type="text" id="node-config-input-name" data-i18n="[placeholder]coapServer.configInputName.placeholder" />
+        <input type="text" id="node-config-input-name" data-i18n="[placeholder]common.inputName.placeholder" />
     </div>
     <div class="form-row">
         <input type="checkbox" id="node-config-input-ipv6" style="display: inline-block; width: auto; vertical-align: top;">
@@ -66,8 +66,8 @@
         <input type="text" id="node-input-url" data-i18n="[placeholder]coapIn.inputURL.placeholder" />
     </div>
     <div class="form-row">
-        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="coapIn.inputName.label"></span></label>
-        <input type="text" id="node-input-name"  data-i18n="[placeholder]coapIn.inputName.placeholder" />
+        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="common.inputName.label"></span></label>
+        <input type="text" id="node-input-name"  data-i18n="[placeholder]common.inputName.placeholder" />
     </div>
 </script>
 
@@ -112,4 +112,48 @@
             return this.name ? "node_label_italic" : "";
         },
     });
+
+    RED.nodes.registerType('coap response',{
+        category: 'network',
+        color:"#f4a261",
+        defaults: {
+            name: {value:""},
+            statusCode: {value:"",validate: RED.validators.number(true)},
+            contentFormat: { value: "text/plain" },
+        },
+        inputs:1,
+        outputs:0,
+        align: "right",
+        icon: "white-globe.svg",
+        label: function() {
+            return this.name||("coap"+(this.statusCode?" ("+this.statusCode+")":""));
+        },
+        labelStyle: function() {
+            return this.name?"node_label_italic":"";
+        },
+    });
+</script>
+
+<script type="text/html" data-template-name="coap response">
+    <div class="form-row">
+        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="common.inputName.label"></span></label>
+        <input type="text" id="node-input-name" data-i18n="[placeholder]common.inputName.placeholder">
+    </div>
+    <div class="form-row">
+        <label for="node-input-statusCode"><i class="fa fa-long-arrow-left"></i> <span data-i18n="coapResponse.statusCode.label"></span></label>
+        <input type="text" id="node-input-statusCode" placeholder="msg.statusCode">
+    </div>
+    <div class="form-row">
+        <label for="node-input-contentFormat">
+            <i class="fa fa-file"></i> <span data-i18n="coapResponse.contentFormat.label"></span>
+        </label>
+        <select id="node-input-contentFormat">
+            <option>text/plain</option>
+            <option>application/json</option>
+            <option>application/cbor</option>
+        </select>
+    </div>
+    <div class="form-tips">
+        <span data-i18n="[html]coapResponse.tip">
+    </div>
 </script>

--- a/coap/coap-in.js
+++ b/coap/coap-in.js
@@ -1,6 +1,12 @@
 module.exports = function (RED) {
     "use strict";
-    var coap = require("coap");
+    const coap = require("coap");
+    const cbor = require("cbor");
+    const linkFormat = require("h5.linkformat");
+
+    function _checkContentFormat(contentFormat, expectedContentFormat) {
+        return typeof contentFormat === "string" && contentFormat.includes(expectedContentFormat);
+    }
 
     // A node red node that sets up a local coap server
     function CoapServerNode(config) {
@@ -10,7 +16,7 @@ module.exports = function (RED) {
         node._inputNodes = []; // collection of "coap in" nodes that represent coap resources
 
         // Setup node-coap server and start
-        var serverSettings = {};
+        const serverSettings = {};
         if (config.ipv6) {
             serverSettings.type = "udp6";
         } else {
@@ -37,8 +43,8 @@ module.exports = function (RED) {
 
     CoapServerNode.prototype.registerInputNode = function (inputNode) {
         var node = this;
-        var exists = false;
-        for (var i = 0; i < node._inputNodes.length; i++) {
+        let exists = false;
+        for (let i = 0; i < node._inputNodes.length; i++) {
             if (
                 node._inputNodes[i].options.url == inputNode.options.url &&
                 node._inputNodes[i].options.method == inputNode.options.method
@@ -56,18 +62,51 @@ module.exports = function (RED) {
         }
     };
 
+    function _getPayload(inNode, rawBuffer, payload, contentFormat) {
+        if (rawBuffer) {
+            return payload;
+        } else if (_checkContentFormat(contentFormat, "text/plain")) {
+            return payload.toString();
+        } else if (_checkContentFormat(contentFormat, "json")) {
+            return JSON.parse(payload.toString());
+        } else if (_checkContentFormat(contentFormat, "cbor")) {
+            cbor.decodeAll(payload, function (err, decodedPayload, req, res) {
+                if (err) {
+                    inNode.error(err);
+                }
+                return decodedPayload[0];
+            });
+        } else if (_checkContentFormat(contentFormat, "application/link-format")) {
+            return linkFormat.parse(payload.toString());
+        } else {
+            return payload.toString();
+        }
+    }
+
+    function _onRequest(inNode, req, res) {
+        const contentFormat = req.headers["Content-Format"];
+        const payload = _getPayload(inNode, inNode.options.rawBuffer, req.payload, contentFormat);
+
+        inNode.send({
+            payload,
+            contentFormat,
+            req,
+            res
+        });
+    }
+
     CoapServerNode.prototype.handleRequest = function (req, res) {
         //TODO: Check if there are any matching resource. If the resource is .well-known return the resource directory to the client
-        var node = this;
-        var matchResource = false;
-        var matchMethod = false;
-        for (var i = 0; i < node._inputNodes.length; i++) {
+        const node = this;
+        let matchResource = false;
+        let matchMethod = false;
+        for (let i = 0; i < node._inputNodes.length; i++) {
             if (node._inputNodes[i].options.url == req.url) {
                 matchResource = true;
                 if (node._inputNodes[i].options.method == req.method) {
                     matchMethod = true;
-                    var inNode = node._inputNodes[i];
-                    inNode.send({ req: req, res: res });
+                    const inNode = node._inputNodes[i];
+                    _onRequest(inNode, req, res);
                 }
             }
         }
@@ -92,13 +131,72 @@ module.exports = function (RED) {
         node.options.server = config.server;
         node.options.url = config.url.charAt(0) == "/" ? config.url : "/" + config.url;
 
-        var serverConfig = RED.nodes.getNode(config.server);
+        const serverConfig = RED.nodes.getNode(config.server);
 
-        if (serverConfig) {
+        if (serverConfig != null) {
             serverConfig.registerInputNode(node);
         } else {
             node.error("Missing server configuration");
         }
     }
     RED.nodes.registerType("coap in", CoapInNode);
+
+    function _constructPayload(msg, contentFormat) {
+        const payload = msg.payload;
+
+        if (payload == null) {
+            return null;
+        }
+
+        if (_checkContentFormat(contentFormat, "text/plain")) {
+            return msg.payload.toString();
+        } else if (_checkContentFormat(contentFormat, "json")) {
+            return JSON.stringify(msg.payload);
+        } else if (_checkContentFormat(contentFormat, "cbor")) {
+            return cbor.encode(msg.payload);
+        } else {
+            return msg.payload.toString();
+        }
+    }
+
+    function CoapOutNode(config) {
+        RED.nodes.createNode(this, config);
+        var node = this;
+
+        node.options = {
+            name: config.name,
+            code: config.code,
+            contentFormat: config.contentFormat
+        };
+
+        this.on("input", function (msg, _send, done) {
+            let code = this.options.code || msg.statusCode || "2.05";
+            // TODO: Improve contentFormat system
+            const contentFormat = msg.contentFormat || node.options.contentFormat;
+            const payload = _constructPayload(msg, contentFormat);
+
+            if (msg.res) {
+                msg.res.code = code;
+                if (contentFormat != null) {
+                    msg.res.setOption("Content-Format", contentFormat);
+                }
+
+                msg.res.on("error", function (err) {
+                    node.log("server error");
+                    node.log(err);
+                });
+
+                if (payload != null) {
+                    msg.res.write(payload);
+                }
+
+                msg.res.end();
+            } else {
+                node.error("No response found in input node!");
+            }
+
+            done();
+        });
+    }
+    RED.nodes.registerType("coap response", CoapOutNode);
 };

--- a/coap/locales/de/coap-in.html
+++ b/coap/locales/de/coap-in.html
@@ -14,6 +14,21 @@
     </p>
 </script>
 
+<script type="text/html" data-help-name="coap response">
+    <p>Stellt einen Node für das Senden der Antwort eines CoAP-Servers bereit.</p>
+
+    <p>
+        Sie können das <code>Content-Format</code> der Antwort entweder für über die Einstellungen dieses Nodes festlegen
+        oder über das <code>contentFormat</code>-Feld des <code>msg</code>-Objekts.
+        Erlaubte Werte sind <code>text/plain</code>, <code>application/json</code>, oder <code>application/cbor</code>.
+    </p>
+
+    <p>
+        Siehe <a href="https://github.com/mcollina/node-coap">node-coap</a> für mehr Informationen dazu, wie Antworten gehandhabt
+        werden können.
+    </p>
+</script>
+
 <script type="text/html" data-help-name="coap-server">
     <p>
         Dieser Konfigurationsnode erzeugt einen CoAP-Server, der den angegebenen UDP-Port verwendet.

--- a/coap/locales/de/coap-in.json
+++ b/coap/locales/de/coap-in.json
@@ -1,9 +1,11 @@
 {
-    "coapIn": {
+    "common": {
         "inputName": {
             "label": "Name",
             "placeholder": "Name"
-        },
+        }
+    },
+    "coapIn": {
         "inputURL": {
             "label": "URL",
             "placeholder": "/url"
@@ -15,11 +17,16 @@
             "label": "Server"
         }
     },
-    "coapServer": {
-        "configInputName": {
-            "label": "Name",
-            "placeholder": "Name"
+    "coapResponse": {
+        "statusCode": {
+            "label": "Status-Code"
         },
+        "contentFormat": {
+            "label": "Content-Format"
+        },
+        "tip": "Die an diesen Node gesendeten Nachrichten <strong>müssen</strong> von einem <em>coap-Input</em>-Node stammen"
+    },
+    "coapServer": {
         "configInputIPv6": {
             "label": "UDP6-Agent verwenden"
         },

--- a/coap/locales/en-US/coap-in.html
+++ b/coap/locales/en-US/coap-in.html
@@ -13,6 +13,20 @@
     </p>
 </script>
 
+<script type="text/html" data-help-name="coap response">
+    <p>Provides a node for sending the actual response from a CoAP server.</p>
+
+    <p>
+        You can either set the <code>Content-Format</code> of the response in the settings of this node or via
+        the <code>contentFormat</code> field of the <code>msg</code> object.
+        Allowed values are <code>text/plain</code>, <code>application/json</code>, or <code>application/cbor</code>.
+    </p>
+
+    <p>
+        See <a href="https://github.com/mcollina/node-coap">node-coap</a> for more details on how to handle responses.
+    </p>
+</script>
+
 <script type="text/html" data-help-name="coap-server">
     <p>
         This configuration node creates a CoAP Server using the specified UDP port

--- a/coap/locales/en-US/coap-in.json
+++ b/coap/locales/en-US/coap-in.json
@@ -1,9 +1,11 @@
 {
-    "coapIn": {
+    "common": {
         "inputName": {
             "label": "Name",
             "placeholder": "Name"
-        },
+        }
+    },
+    "coapIn": {
         "inputURL": {
             "label": "URL",
             "placeholder": "/url"
@@ -15,11 +17,16 @@
             "label": "Server"
         }
     },
-    "coapServer": {
-        "configInputName": {
-            "label": "Name",
-            "placeholder": "Name"
+    "coapResponse": {
+        "statusCode": {
+            "label": "Status-Code"
         },
+        "contentFormat": {
+            "label": "Content-Format"
+        },
+        "tip": "The messages sent to this node <strong>must</strong> originate from an <em>coap input</em> node."
+    },
+    "coapServer": {
         "configInputIPv6": {
             "label": "Use UDP6 agent"
         },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "reporter": "spec"
   },
   "jshintConfig": {
+    "esversion": 6,
     "curly": true,
     "forin": true,
     "immed": true,

--- a/test/coap-in_spec.js
+++ b/test/coap-in_spec.js
@@ -128,11 +128,19 @@ describe("CoapInNode", function () {
                                 {
                                     id: "n3",
                                     type: "function",
-                                    name: "coapOutGet",
+                                    name: "setPayload",
                                     func:
-                                        "msg.res.end('" +
+                                        "msg.payload = '" +
                                         test.message +
-                                        "');\nreturn msg;",
+                                        "';\nreturn msg;",
+                                    wires: [["n4"]],
+                                },
+                                {
+                                    id: "n4",
+                                    type: "coap response",
+                                    name: "coapOutGet",
+                                    statusCode: "",
+                                    contentFormat: "text/plain",
                                     wires: [],
                                 },
                             ];
@@ -176,7 +184,7 @@ describe("CoapInNode", function () {
             ];
 
             // Need to register nodes in order to use them
-            var testNodes = [functionNode, coapInNode];
+            var testNodes = [coapInNode];
             helper.load(testNodes, flow, function () {
                 var req = coap.request("coap://localhost:8888/test");
                 req.statusCode = "PUT"


### PR DESCRIPTION
This PR will add a reponse node to the package that is similar to the HTTP response node in the core package.

At the moment, as it was discussed in issue #14, sending an actual response after an incoming request requires a function node which calls `msg.res.end()` which is rather unintuitive. Having a dedicated reponse node will make flows more easy to understand. It will also enable the package to implement more features from the specifications, for example the handling of different media types and options from requests.

This PR is still WIP. Once it is finished it will resolve #20.