### PR TITLE
Fix for en-US locale

### DIFF
--- a/coap/locales/en-US/coap-request.json
+++ b/coap/locales/en-US/coap-request.json
@@ -21,10 +21,10 @@
         "inputObserve": {
             "label": "Observe?"
         },
-        "rawBuffer": {
+        "inputRawBuffer": {
             "label": "Raw buffer?"
         },
-        "contentFormat": {
+        "inputContentFormat": {
             "label": "Content format"
         },
         "tip": "Tip: Leave url or method blank if you want to set them via msg properties."


### PR DESCRIPTION
Text missing in node running en-US locale

![image](https://user-images.githubusercontent.com/9595798/111211813-262add80-85cf-11eb-9580-c3f3009a5c27.png)
