### PR TITLE
Add Windows and Mac OS to CI pipeline tests

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -9,11 +9,12 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         node-version: [10.x, 12.x, 14.x, 15.x]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
With this PR, tests in the CI pipeline are not only performed on `ubuntu-latest` anymore but also on `macos-latest` and `windows-latest`.