### PR TITLE
Add handler for ./well-known/core

### DIFF
--- a/coap/coap-in.html
+++ b/coap/coap-in.html
@@ -7,12 +7,16 @@
         <input type="text" id="node-config-input-name" data-i18n="[placeholder]coapServer.configInputName.placeholder" />
     </div>
     <div class="form-row">
-        <input type="checkbox" id="node-input-ipv6" style="display: inline-block; width: auto; vertical-align: top;">
-        <label for="node-input-ipv6" style="width: auto" data-i18n="coapServer.configInputIPv6.label"></label>
-    </div>
-    <div class="form-row">
         <label for="node-config-input-port"><span data-i18n="coapServer.configInputPort.label"></span></label>
         <input type="text" id="node-config-input-port" placeholder="5683" />
+    </div>
+    <div class="form-row">
+        <input type="checkbox" id="node-config-input-wellknowncore" style="display: inline-block; width: auto; vertical-align: top;">
+        <label for="node-config-input-wellknowncore" style="width: auto" data-i18n="coapServer.configInputwellKnownCore.label"></label>
+    </div>
+    <div class="form-row">
+        <input type="checkbox" id="node-config-input-ipv6" style="display: inline-block; width: auto; vertical-align: top;">
+        <label for="node-config-input-ipv6" style="width: auto" data-i18n="coapServer.configInputIPv6.label"></label>
     </div>
     <div class="form-tips">
         <span data-i18n="[html]coapServer.tip">
@@ -26,6 +30,7 @@
             name: { value: "" },
             port: { value: 5683, required: true },
             ipv6: { value: true, required: true },
+            wellknowncore: { value: false, required: true },
         },
         inputs: 0,
         outputs: 0,

--- a/coap/coap-in.js
+++ b/coap/coap-in.js
@@ -13,8 +13,10 @@ module.exports = function (RED) {
         node.options.name = n.name;
         node.options.port = n.port;
         node.options.ipv6 = n.ipv6;
+        node.options.wellknowncore = n.wellknowncore;
 
         node._inputNodes = []; // collection of "coap in" nodes that represent coap resources
+        node._resourceList = []; // resource list for /.well-known/core
 
         // Setup node-coap server and start
         var serverSettings = {};
@@ -32,7 +34,6 @@ module.exports = function (RED) {
             });
         });
         node.server.listen(node.options.port, function () {
-            //console.log('server started');
             node.log("CoAP Server Started");
         });
 
@@ -44,27 +45,45 @@ module.exports = function (RED) {
     RED.nodes.registerType("coap-server", CoapServerNode);
 
     CoapServerNode.prototype.registerInputNode = function (/*Node*/ resource) {
-        var exists = false;
+        var urlExists = false;
+        var methodExists = false;
+        var newNodeOptions = resource.options;
         for (var i = 0; i < this._inputNodes.length; i++) {
-            if (
-                this._inputNodes[i].options.url == resource.options.url &&
-                this._inputNodes[i].options.method == resource.options.method
-            ) {
-                exists = true;
-
-                //TODO: Does this have any effect? Should show the error in the frontend somehow? Some kind of status bar?
-                this.error(
-                    "Node with the specified URL and Method already exists!"
-                );
+            let existingNodeOptions = this._inputNodes[i].options;
+            if (existingNodeOptions.url == newNodeOptions.url) {
+                urlExists = true;
+                if (existingNodeOptions.method == newNodeOptions.method) {
+                    methodExists = true;
+    
+                    //TODO: Does this have any effect? Should show the error in the frontend somehow? Some kind of status bar?
+                    this.error("Node with the specified URL and Method already exists!");
+                }
             }
         }
-        if (!exists) {
-            this._inputNodes.push(resource);
+        if (!urlExists) {
+            this._resourceList.push(newNodeOptions.url);
+            if (!methodExists) {
+                this._inputNodes.push(resource);
+            }
         }
     };
 
+    CoapServerNode.prototype._handleWellKnownCore = function (res) {
+        // TODO: Expand capabilities of the handler for /.well-known/core
+        let formattedResources = this._resourceList.map(function (resource) {
+            return `<${resource}>`;
+        })
+        let payload = formattedResources.join(",");
+        res.code = "2.05";
+        res.setOption("Content-Format", "application/link-format");
+        return res.end(payload);
+    }
+
     CoapServerNode.prototype.handleRequest = function (req, res) {
-        //TODO: Check if there are any matching resource. If the resource is .well-known return the resource directory to the client
+        if (this.options.wellknowncore && req.url == "/.well-known/core" && req.method == "GET") {
+            return this._handleWellKnownCore(res);
+        }
+
         var matchResource = false;
         var matchMethod = false;
         for (var i = 0; i < this._inputNodes.length; i++) {

--- a/coap/locales/de/coap-in.json
+++ b/coap/locales/de/coap-in.json
@@ -26,6 +26,9 @@
         "configInputPort": {
             "label": "Port"
         },
+        "configInputwellKnownCore": {
+            "label": "/.well-known/core aktivieren"
+        },
         "tip": "<em>CoAP</em> basiert auf <em>UDP</em>, weshalb es sein kann, dass Sie einen <em>UDP</em>-Port in Ihrer Firewall öffnen müssen."
     }
 }

--- a/coap/locales/en-US/coap-in.json
+++ b/coap/locales/en-US/coap-in.json
@@ -26,6 +26,9 @@
         "configInputPort": {
             "label": "Port"
         },
+        "configInputwellKnownCore": {
+            "label": "Activate /.well-known/core"
+        },
         "tip": "<em>CoAP</em> is based on <em>UDP</em> so you may need to open a <em>UDP</em> port in your firewall."
     }
 }


### PR DESCRIPTION
This PR will implement a handler for `/.well-known/core` to support resource discovery using the CoRE Link Format (see [RFC 6690](https://tools.ietf.org/html/rfc6690)). Once it is finished, it will resolve #2.

So far, only the available (unique) URLs are included in the payload that is returned by the handler for `/.well-known/core` as the setting of like `ct` or `rt` probably needs a way to defined resources on a "global" level so that the definitions in the `coap in` nodes don't contradict each other. I will have a deeper look into this while investigating the possibilities for implementing this feature.