### PR TITLE
Change color schema

### DIFF
--- a/coap/coap-in.html
+++ b/coap/coap-in.html
@@ -88,7 +88,7 @@
             server: { type: "coap-server", required: true },
             url: { required: true },
         },
-        color: "rgb(215, 215, 160)",
+        color: "#f4a261",
         inputs: 0,
         outputs: 1,
         icon: "white-globe.png",

--- a/coap/coap-request.html
+++ b/coap/coap-request.html
@@ -1,7 +1,7 @@
 <script type="text/javascript">
     RED.nodes.registerType("coap request", {
         category: "network",
-        color: "rgb(215, 215, 160)",
+        color: "#f4a261",
         defaults: {
             method: {
                 value: "GET",


### PR DESCRIPTION
This PR will change the colors of the `coap in` and `coap request` nodes to make them more distinguishable from other nodes. At the moment, I would like to use orange (`#f4a261`) as a color but I am open for any suggestions. With an orange color scheme the nodes would look like this:

![grafik](https://user-images.githubusercontent.com/12641361/111325835-5d030100-866c-11eb-83d9-291e6aa2b5b2.png)

(The screenshot already includes the `coap response` node that is about to be added by PR #27.)