### PR TITLE
chore: remove obsolete URI module

### DIFF
--- a/coap/coap-request.js
+++ b/coap/coap-request.js
@@ -3,7 +3,6 @@ module.exports = function (RED) {
 
     var coap = require("coap");
     var cbor = require("cbor");
-    var url = require("uri-js");
     var linkFormat = require("h5.linkformat");
 
     function CoapRequestNode(n) {
@@ -35,8 +34,14 @@ module.exports = function (RED) {
         }
 
         function _makeRequest(msg) {
-            var reqOpts = url.parse(node.options.url || msg.url);
-            reqOpts.pathname = reqOpts.path;
+            var url = new URL(node.options.url || msg.url);
+
+            var reqOpts = {
+                hostname: url.hostname,
+                pathname: url.pathname,
+                port: url.port,
+                query: url.search.substring(1),
+            };
             reqOpts.method = (
                 node.options.method ||
                 msg.method ||

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "dependencies": {
         "cbor": "^8.0.0",
         "coap": "^0.25.0",
-        "h5.linkformat": "0.0.0",
-        "uri-js": "^4.4.1"
+        "h5.linkformat": "0.0.0"
       },
       "devDependencies": {
         "coveralls": "^3.1.1",
@@ -5270,6 +5269,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -6424,6 +6424,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -10995,7 +10996,8 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "qs": {
       "version": "6.7.0",
@@ -11919,6 +11921,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "dependencies": {
     "cbor": "^8.0.0",
     "coap": "^0.25.0",
-    "h5.linkformat": "0.0.0",
-    "uri-js": "^4.4.1"
+    "h5.linkformat": "0.0.0"
   },
   "devDependencies": {
     "coveralls": "^3.1.1",

--- a/test/coap-in_spec.js
+++ b/test/coap-in_spec.js
@@ -1,7 +1,6 @@
 var should = require("should");
 
 var coap = require("coap");
-var url = require("url");
 var coapInNode = require("../coap/coap-in.js");
 var functionNode = require("@node-red/nodes/core/function/10-function.js");
 var helper = require("node-red-node-test-helper");
@@ -70,10 +69,7 @@ describe("CoapInNode", function () {
 
         // Need to register nodes in order to use them
         helper.load(coapInNode, flow, function () {
-            var urlStr = "coap://localhost:8888/unregistered";
-            var opts = url.parse(urlStr);
-            opts.method = "GET";
-            var req = coap.request(opts);
+            var req = coap.request("coap://localhost:8888/unregistered");
 
             req.on("response", function (res) {
                 res.code.should.equal("4.04");
@@ -144,11 +140,8 @@ describe("CoapInNode", function () {
                             // Need to register nodes in order to use them
                             var testNodes = [functionNode, coapInNode];
                             helper.load(testNodes, flow, function () {
-                                var urlStr =
-                                    "coap://" + serverAddress + ":8888/test";
-                                var opts = url.parse(urlStr);
-                                opts.method = test.method;
-                                var req = coap.request(opts);
+                                var req = coap.request("coap://" + serverAddress + ":8888/test");
+                                req.statusCode = test.method;
 
                                 req.on("response", function (res) {
                                     res.payload
@@ -185,10 +178,8 @@ describe("CoapInNode", function () {
             // Need to register nodes in order to use them
             var testNodes = [functionNode, coapInNode];
             helper.load(testNodes, flow, function () {
-                var urlStr = "coap://localhost:8888/test";
-                var opts = url.parse(urlStr);
-                opts.method = "PUT";
-                var req = coap.request(opts);
+                var req = coap.request("coap://localhost:8888/test");
+                req.statusCode = "PUT"
 
                 req.on("response", function (res) {
                     res.code.should.equal("4.05");


### PR DESCRIPTION
This PR removes the obsolete `uri-js` module from the project and replaces it with native `URL` objects.