### PR TITLE
refactor: clean up `coap-request` and `coap-in` nodes

### DIFF
--- a/coap/coap-in.js
+++ b/coap/coap-in.js
@@ -35,12 +35,12 @@ module.exports = function (RED) {
     }
     RED.nodes.registerType("coap-server", CoapServerNode);
 
-    CoapServerNode.prototype.registerInputNode = function (/*Node*/ resource) {
+    CoapServerNode.prototype.registerInputNode = function (inputNode) {
         var exists = false;
         for (var i = 0; i < this._inputNodes.length; i++) {
             if (
-                this._inputNodes[i].options.url == resource.options.url &&
-                this._inputNodes[i].options.method == resource.options.method
+                this._inputNodes[i].options.url == inputNode.options.url &&
+                this._inputNodes[i].options.method == inputNode.options.method
             ) {
                 exists = true;
 
@@ -51,7 +51,7 @@ module.exports = function (RED) {
             }
         }
         if (!exists) {
-            this._inputNodes.push(resource);
+            this._inputNodes.push(inputNode);
         }
     };
 

--- a/coap/coap-in.js
+++ b/coap/coap-in.js
@@ -3,22 +3,15 @@ module.exports = function (RED) {
     var coap = require("coap");
 
     // A node red node that sets up a local coap server
-    function CoapServerNode(n) {
-        // Create a RED node
-        RED.nodes.createNode(this, n);
+    function CoapServerNode(config) {
+        RED.nodes.createNode(this, config);
         var node = this;
-
-        // Store local copies of the node configuration (as defined in the .html)
-        node.options = {};
-        node.options.name = n.name;
-        node.options.port = n.port;
-        node.options.ipv6 = n.ipv6;
 
         node._inputNodes = []; // collection of "coap in" nodes that represent coap resources
 
         // Setup node-coap server and start
         var serverSettings = {};
-        if (node.options.ipv6) {
+        if (config.ipv6) {
             serverSettings.type = "udp6";
         } else {
             serverSettings.type = "udp4";
@@ -31,8 +24,7 @@ module.exports = function (RED) {
                 node.log(err);
             });
         });
-        node.server.listen(node.options.port, function () {
-            //console.log('server started');
+        node.server.listen(config.port, function () {
             node.log("CoAP Server Started");
         });
 
@@ -88,22 +80,22 @@ module.exports = function (RED) {
         }
     };
 
-    function CoapInNode(n) {
-        RED.nodes.createNode(this, n);
+    function CoapInNode(config) {
+        RED.nodes.createNode(this, config);
+        var node = this;
 
-        //copy "coap in" node configuration locally
-        this.options = {};
-        this.options.method = n.method;
-        this.options.name = n.name;
-        this.options.server = n.server;
-        this.options.url = n.url.charAt(0) == "/" ? n.url : "/" + n.url;
+        node.options = {};
+        node.options.method = config.method;
+        node.options.name = config.name;
+        node.options.server = config.server;
+        node.options.url = config.url.charAt(0) == "/" ? config.url : "/" + config.url;
 
-        this.serverConfig = RED.nodes.getNode(this.options.server);
+        var serverConfig = RED.nodes.getNode(config.server);
 
-        if (this.serverConfig) {
-            this.serverConfig.registerInputNode(this);
+        if (serverConfig) {
+            serverConfig.registerInputNode(node);
         } else {
-            this.error("Missing server configuration");
+            node.error("Missing server configuration");
         }
     }
     RED.nodes.registerType("coap in", CoapInNode);

--- a/coap/coap-in.js
+++ b/coap/coap-in.js
@@ -36,35 +36,37 @@ module.exports = function (RED) {
     RED.nodes.registerType("coap-server", CoapServerNode);
 
     CoapServerNode.prototype.registerInputNode = function (inputNode) {
+        var node = this;
         var exists = false;
-        for (var i = 0; i < this._inputNodes.length; i++) {
+        for (var i = 0; i < node._inputNodes.length; i++) {
             if (
-                this._inputNodes[i].options.url == inputNode.options.url &&
-                this._inputNodes[i].options.method == inputNode.options.method
+                node._inputNodes[i].options.url == inputNode.options.url &&
+                node._inputNodes[i].options.method == inputNode.options.method
             ) {
                 exists = true;
 
                 //TODO: Does this have any effect? Should show the error in the frontend somehow? Some kind of status bar?
-                this.error(
+                node.error(
                     "Node with the specified URL and Method already exists!"
                 );
             }
         }
         if (!exists) {
-            this._inputNodes.push(inputNode);
+            node._inputNodes.push(inputNode);
         }
     };
 
     CoapServerNode.prototype.handleRequest = function (req, res) {
         //TODO: Check if there are any matching resource. If the resource is .well-known return the resource directory to the client
+        var node = this;
         var matchResource = false;
         var matchMethod = false;
-        for (var i = 0; i < this._inputNodes.length; i++) {
-            if (this._inputNodes[i].options.url == req.url) {
+        for (var i = 0; i < node._inputNodes.length; i++) {
+            if (node._inputNodes[i].options.url == req.url) {
                 matchResource = true;
-                if (this._inputNodes[i].options.method == req.method) {
+                if (node._inputNodes[i].options.method == req.method) {
                     matchMethod = true;
-                    var inNode = this._inputNodes[i];
+                    var inNode = node._inputNodes[i];
                     inNode.send({ req: req, res: res });
                 }
             }

--- a/test/coap-request_spec.js
+++ b/test/coap-request_spec.js
@@ -29,32 +29,6 @@ describe("CoapRequestNode", function () {
         });
     });
 
-    it("should be loaded", function (done) {
-        var flow = [
-            {
-                id: "coapRequest1",
-                type: "coap request",
-                "content-format": "application/json",
-                method: "POST",
-                name: "coapRequestPost",
-                observe: false,
-                url: "/test-resource",
-            },
-        ];
-
-        helper.load([coapRequestNode], flow, function () {
-            var coapRequest1 = helper.getNode("coapRequest1");
-            coapRequest1.options.should.have.property("method", "POST");
-            coapRequest1.options.should.have.property(
-                "name",
-                "coapRequestPost"
-            );
-            coapRequest1.options.should.have.property("observe", false);
-            coapRequest1.options.should.have.property("url", "/test-resource");
-            done();
-        });
-    });
-
     describe("Methods", function () {
         var methodTests = [
             { method: "GET", message: "You get me, buddy" },


### PR DESCRIPTION
This PR performs some cleanup by using the `config` object that is passed to nodes directly instead of copying its fields. A test that has become obsolete in this process is removed while doing so.