### PR TITLE
chore: set node 12 as the minimum version

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,5 +72,8 @@
     {
       "name": "Jan Romann"
     }
-  ]
+  ],
+  "engines": {
+    "node": ">=12"
+  }
 }


### PR DESCRIPTION
As the project does not work with node versions below 12, this PR updates the `package.json` file accordingly.