### PR TITLE
chore: add minimum node-red version

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "cbor"
   ],
   "node-red": {
+    "version": ">=1.3.0",
     "nodes": {
       "coap-in": "coap/coap-in.js",
       "coap-request": "coap/coap-request.js"


### PR DESCRIPTION
This PR indicates the minimum node-red version in `package.json`, fixing an issue with the package score on [flows.nodered.org](https://flows.nodered.org/node/node-red-contrib-coap/scorecard).