### PR TITLE
chore: let CI run on all Node LTS versions

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 15.x]
+        node-version: [12.x, 14.x, 16.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:


### PR DESCRIPTION
This PR replaces Node 15 with Node 16 for the tests in the CI pipeline.

The pipeline has to be updated again at the end of this month, when Node 12 reaches EOL status.