### PR TITLE
fix: use default CoAP port as fallback for request URLs

### DIFF
--- a/coap/coap-request.js
+++ b/coap/coap-request.js
@@ -1,3 +1,5 @@
+const defaultCoapPort = 5683;
+
 module.exports = function (RED) {
     "use strict";
 
@@ -39,14 +41,24 @@ module.exports = function (RED) {
             return hostname;
         }
 
+        function _determinePort(url) {
+            const port = parseInt(url.port);
+            if (isNaN(port)) {
+                return defaultCoapPort;
+            }
+
+            return port;
+        }
+
         function _makeRequest(msg) {
             const url = new URL(config.url || msg.url);
             const hostname = _determineHostname(url);
+            const port = _determinePort(url);
 
             const reqOpts = {
                 hostname,
                 pathname: url.pathname,
-                port: url.port,
+                port,
                 query: url.search.substring(1),
             };
             reqOpts.method = (

--- a/test/coap-request_spec.js
+++ b/test/coap-request_spec.js
@@ -448,6 +448,43 @@ describe("CoapRequestNode", function () {
         });
     });
 
+    it("should use the default CoAP port if no port is provided in the request URL", function (done) {
+        const port = 5683;
+        const flow = [
+            {
+                id: "n1",
+                type: "inject",
+                name: "inject",
+                payload: "",
+                payloadType: "none",
+                repeat: "",
+                crontab: "",
+                once: true,
+                wires: [["n2"]],
+            },
+            {
+                id: "n2",
+                type: "coap request",
+                "content-format": "text/plain",
+                method: "",
+                name: "coapRequest",
+                observe: false,
+                url: "coap://localhost/test-resource",
+            },
+        ];
+
+        const testNodes = [coapRequestNode, injectNode];
+
+        const server = coap.createServer();
+        server.on("request", (req, res) => {
+            req.method.should.equal("GET");
+            done();
+        });
+        helper.load(testNodes, flow, () => {
+            server.listen(port);
+        });
+    });
+
     it("should use msg.url", function (done) {
         var port = getPort();
         var flow = [


### PR DESCRIPTION
This PR fixes the error

```
RangeError: Port should be > 0 and < 65536. Received .
```

that occurred when passing a URL to the request node that contained no explicit port number.