### PR TITLE
Fix status Code in coap-in.js

### DIFF
--- a/coap/coap-in.js
+++ b/coap/coap-in.js
@@ -165,7 +165,7 @@ module.exports = function (RED) {
 
         node.options = {
             name: config.name,
-            code: config.code,
+            code: config.statusCode,
             contentFormat: config.contentFormat
         };
 


### PR DESCRIPTION
Fix status Code in coap-in.js from `code: config.code,` to `code: config.statusCode,`

status code was always "2.05" from `let code = this.options.code || msg.statusCode || "2.05";`

With this fix you can now set the status code.