### PR TITLE
ci: use current node versions for testing

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [18.x, 20.x, 22.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:


### PR DESCRIPTION
The CI pipelines for the currently open PRs are currently failign since the Node versions used for testing are outdated. This PR performs an update making it possible to run the CI again.